### PR TITLE
stm32h5xx_hal_mdf.h: Moves the cpp guard outside of MDF1

### DIFF
--- a/Inc/stm32h5xx_hal_mdf.h
+++ b/Inc/stm32h5xx_hal_mdf.h
@@ -1150,10 +1150,10 @@ uint32_t             HAL_MDF_GetError(const MDF_HandleTypeDef *hmdf);
   * @}
   */
 
+#endif /* MDF1 */
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* MDF1 */
 
 #endif /* STM32H5xx_HAL_MDF_H */


### PR DESCRIPTION
Fixes [Issue 32](https://github.com/STMicroelectronics/STM32CubeH5/issues/32)

Moves the cpp guard outside MDF1.

This is a resubmit of a [previous PR ](https://github.com/STMicroelectronics/stm32h5xx-hal-driver/pull/23)after signing the Contribution License Agreement.