### PR TITLE
Implement timeout for SPI peripheral disable

### DIFF
--- a/Src/stm32h5xx_hal_spi.c
+++ b/Src/stm32h5xx_hal_spi.c
@@ -3925,6 +3925,9 @@ static void SPI_CloseTransfer(SPI_HandleTypeDef *hspi)
   __HAL_SPI_CLEAR_TXTFFLAG(hspi);
 
   /* Disable SPI peripheral */
+  int32_t timeout = 1000;
+  while ((hspi->Instance->SR & SPI_SR_TXC) == 0)
+    if (timeout-- <= 0) break;
   __HAL_SPI_DISABLE(hspi);
 
   /* Disable ITs */


### PR DESCRIPTION
Added a timeout mechanism to the SPI disable process.

When running STM32H563ZI on NUCLEO-H563ZI at 250MHz the SPI is disable already during last clock cycle of the sent data bit which is a little bit to early and the clock high signal is teared down. Better to check the TXC flag (TxFIFO transmission complete)  in the status register (SPI_SR) and wait until  it is 1 (= last TxFIFO frame transmission complete).
------