### PR TITLE
[HAL][ETH] fix ETH RX timestamp context handling

### DIFF
--- a/Src/stm32h5xx_hal_eth.c
+++ b/Src/stm32h5xx_hal_eth.c
@@ -1071,6 +1071,7 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
   uint32_t desccntmax;
   uint32_t bufflength;
   uint8_t rxdataready = 0U;
+  uint8_t rxcontextfound = 0U;
 
   if (pAppBuff == NULL)
   {
@@ -1082,6 +1083,9 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
   {
     return HAL_ERROR;
   }
+
+  heth->RxDescList.TimeStamp.TimeStampHigh = UINT32_MAX;
+  heth->RxDescList.TimeStamp.TimeStampLow = UINT32_MAX;
 
   descidx = heth->RxDescList.RxDescIdx;
   dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
@@ -1120,8 +1124,10 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
 
           dmarxdesc_next = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx_next];
 
-          if (READ_BIT(dmarxdesc_next->DESC3, ETH_DMARXNDESCWBF_CTXT) != (uint32_t)RESET)
+          if ((READ_BIT(dmarxdesc_next->DESC3, ETH_DMARXNDESCWBF_OWN) == (uint32_t)RESET) &&
+              (READ_BIT(dmarxdesc_next->DESC3, ETH_DMARXNDESCWBF_CTXT) != (uint32_t)RESET))
           {
+            rxcontextfound = 1U;
             /* Get timestamp high */
             heth->RxDescList.TimeStamp.TimeStampHigh = dmarxdesc_next->DESC1;
             /* Get timestamp low */
@@ -1152,6 +1158,14 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
     /* Get current descriptor address */
     dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
     desccnt++;
+
+    if (rxcontextfound != 0U)
+    {
+      INCR_RX_DESC_INDEX(descidx, 1U);
+      dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+      desccnt++;
+      rxcontextfound = 0U;
+    }
   }
 
   heth->RxDescList.RxBuildDescCnt += desccnt;


### PR DESCRIPTION
This PR is a copy of the PR from the Zephyr [hal_stm32](https://github.com/zephyrproject-rtos/hal_stm32) repo:
https://github.com/zephyrproject-rtos/hal_stm32/pull/374

as suggested by @erwango in his comment I create the PR here too (https://github.com/zephyrproject-rtos/hal_stm32/pull/374#pullrequestreview-4434015329)

Furthermore please note the following from my answer to the comment of @erwango :

> I checked the other Ethernet HAL implementations. The same fix appears applicable to STM32H7, STM32H7RS, and STM32N6, with minor adaptation for N6's channel-indexed descriptor state. STM32MP13 and MP2 have related context-descriptor handling that should also be reviewed, although the implementation differs. STM32F4 and F7 use the legacy descriptor format and are not affected by this specific issue. This is based on static code inspection. I have only tested the fix on STM32H5 because I currently don't own any other STM32 dev board.

## Summary

Fix STM32H5 Ethernet RX timestamp context handling.

`HAL_ETH_ReadData()` could report stale or incomplete RX timestamps when PTP hardware timestamping was enabled. This happened because the HAL cached the last RX timestamp and read the descriptor after a timestamped packet without first checking whether that descriptor was already CPU-owned and marked as a context descriptor.

## Problem

With PTP traffic, STM32 Ethernet can place the RX hardware timestamp in a context descriptor following the received packet descriptor.

The previous code checked the following descriptor for `CTXT`, but did not check whether DMA still owned it. If the context descriptor was not ready yet, the HAL could read incomplete descriptor contents. If no fresh timestamp was produced,
the cached `RxDescList.TimeStamp` value could also make the caller see an old timestamp as if it belonged to the current packet.

Downstream, this showed up as occasional bad PTP RX timestamps, which caused large Sync/Pdelay time jumps and unstable clock correction.

## Solution

Clear the cached RX timestamp before reading a packet.

Only consume the following descriptor as an RX timestamp context descriptor when:
- DMA no longer owns the descriptor
- the descriptor is marked as a context descriptor

When a valid timestamp context descriptor is consumed, advance the RX descriptor index past it so the RX ring stays aligned.

## Testing

Tested downstream with Zephyr STM32H5 PTP traffic. The previous intermittent PTP timestamp warnings no longer reproduced during the follow-up long run.